### PR TITLE
add repository url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "gcp",
     "googlecloudplatform"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GoogleCloudPlatform/winston-gae.git"
+  },
+  "homepage": "https://github.com/GoogleCloudPlatform/winston-gae#readme",
   "devDependencies": {
     "winston": ">=0.6.x"
   },


### PR DESCRIPTION
https://www.npmjs.com/package/winston-gae
I want to see this repository url in npm package page.

---

I sent CLA to Google at 2014/07/31.
I read https://github.com/GoogleCloudPlatform/winston-gae/blob/master/CONTRIBUTING.md but this repository closes issue page.
