### PR TITLE
make log output dir before running

### DIFF
--- a/lib/winston-gae.js
+++ b/lib/winston-gae.js
@@ -12,9 +12,18 @@ limitations under the License.
 */
 
 var winston = require('winston'),
+    mkdirp = require('mkdirp'),
     util = require('util'),
     os = require('os'),
     fs = require('fs');
+
+var logDir = '/var/log/app_engine/';
+
+try {
+    mkdirp.sync(logDir);
+} catch(e) {
+    console.error(e);
+}
 
 var GoogleAppEngine = exports.GoogleAppEngine = function (options) {
     options = options || {};
@@ -73,5 +82,5 @@ GoogleAppEngine.prototype.log = function (level, msg, meta, callback) {
     };
 
     var line = JSON.stringify(output) + os.EOL;
-    fs.appendFile('/var/log/app_engine/app.log.json', line, callback);
+    fs.appendFile(logDir + 'app.log.json', line, callback);
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "gcp",
     "googlecloudplatform"
   ],
+  "dependencies": {
+    "mkdirp": "^0.5.1"
+  },
   "devDependencies": {
     "winston": ">=0.6.x"
   },


### PR DESCRIPTION
in `gcr.io/google_appengine/nodejs`.

```
 ---> 7211968992fd
Removing intermediate container 153ee0d10494
Step 12 : RUN ls /var/log/
 ---> Running in ecc11e78032e
alternatives.log
apt
bootstrap.log
btmp
dmesg
dpkg.log
faillog
fsck
lastlog
wtmp
```

`/var/log/app_engine/` is not exists.

---

I sent CLA to Google at 2014/07/31.
I read https://github.com/GoogleCloudPlatform/winston-gae/blob/master/CONTRIBUTING.md but this repository closes issue page.
